### PR TITLE
Add option to only temporarily store generated assemblies

### DIFF
--- a/Westwind.Scripting/CSharpScriptExecution.cs
+++ b/Westwind.Scripting/CSharpScriptExecution.cs
@@ -118,6 +118,7 @@ namespace Westwind.Scripting
         /// </summary>
         public bool CompileWithDebug { get; set; }
 
+#if NETCORE
         /// <summary>
         /// The AssemblyLoadContext the assembly should be loaded in.
         /// If not assigned, assemblies will get loaded by the default Assembly.Load methods
@@ -125,6 +126,7 @@ namespace Westwind.Scripting
         /// This allows for unloading of the loaded assemblies
         /// </summary>
         public AssemblyLoadContext AlternateAssemblyLoadContext { get; set; }
+#endif
 
         /// <summary>
         /// If disabled, assemblies will not be cached through hashes
@@ -1628,20 +1630,24 @@ public bool AddAssembly(Type type)
 
         private Assembly LoadAssembly(byte[] rawAssembly)
         {
-            if (AlternateAssemblyLoadContext == null)
+#if NETCORE
+            if (AlternateAssemblyLoadContext != null)
             {
-                return Assembly.Load(rawAssembly);
+                return AlternateAssemblyLoadContext.LoadFromStream(new MemoryStream(rawAssembly));
             }
-            return AlternateAssemblyLoadContext.LoadFromStream(new MemoryStream(rawAssembly));
+#endif
+            return Assembly.Load(rawAssembly);
         }
 
         private Assembly LoadAssemblyFrom(string assemblyFile)
         {
-            if (AlternateAssemblyLoadContext == null)
+#if NETCORE
+            if (AlternateAssemblyLoadContext != null)
             {
-                return Assembly.LoadFrom(assemblyFile);
+                return AlternateAssemblyLoadContext.LoadFromAssemblyPath(assemblyFile);
             }
-            return AlternateAssemblyLoadContext.LoadFromAssemblyPath(assemblyFile);
+#endif
+            return Assembly.LoadFrom(assemblyFile);
         }
 
         #endregion

--- a/Westwind.Scripting/Westwind.Scripting.csproj
+++ b/Westwind.Scripting/Westwind.Scripting.csproj
@@ -56,6 +56,7 @@ Features:
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="4.4.0" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
I am trying to use this package in a library which will be used to compile and execute temporary pieces of code. Think of .NET Fiddle combined with a sort of Advent of Code or Euler project. In an online interactive course students will have to do coding challenges; solve problems with C# while learning new skills. Because it will be used in a server application, it's unnecessary and also impractical to store each assembly generated by each attempt of a student. This would put unnecessary memory pressure on the application.

There are two reasons `Westwind.Scripting` causes the assemblies to remain in memory forever:

1. It uses `Assembly.Load` to load assemblies in the default loading context, even on .NET 6.0 and newer.
2. It caches the assemblies by hashing the code and storing the generated assembly for each unique code hash.

Reason 1 would usually be solved by using an `AppDomain` to be able to unload the assemblies that are currently loaded. But those are only supported on .NET Framework. Our application will target .NET 6.0 or 7.0 so this is not an option; we need the `AssemblyLoadContext` which is the official replacement.

Reason 2 has an easier solution, it should be an option to disable the caching of assemblies to truly make it possible to have 'temporary' execution of C# code.

This PR solves both points. `CSharpScriptExecution` has two new properties: `AlternateAssemblyLoadContext` and `DisableAssemblyCaching`. If an alternate `AssemblyLoadContext` is provided, all the assembly loading will be done through that context. If it is not provided, the code will still use `Assembly.Load` for each load. As for the disabled assembly cache, it just prevents the hash generation and cache lookup. Instead it just directly generates a new class and assembly. I've added two tests to showcase both features.

The `AssemblyLoadContext` type is not really supported on .NET Framework so I've marked all code as conditional with `#if NETCORE`. Not pretty but otherwise Visual Studio will ask to add the incomplete/bugged `System.Runtime.Loader` package, letting users believe it could actually work. Perhaps there's a better way to do this but I am unware of how.